### PR TITLE
Feature/set minimum tls version terraform

### DIFF
--- a/pdf-generator/pdf-generator.csproj
+++ b/pdf-generator/pdf-generator.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.5.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
 
     <PackageReference Include="Aspose.Cells" Version="22.3.0" />
     <PackageReference Include="Aspose.Slides.NET" Version="22.2.0" />
@@ -23,7 +23,7 @@
     <PackageReference Include="Aspose.Diagram" Version="22.3.0" />
     <PackageReference Include="Aspose.PDF" Version="22.3.0" />
     <PackageReference Include="Aspose.Email" Version="22.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Domain\Requests\" />

--- a/terraform/functions-coordinator.tf
+++ b/terraform/functions-coordinator.tf
@@ -25,9 +25,12 @@ resource "azurerm_function_app" "fa_coordinator" {
     "OnBehalfOfTokenClientSecret"             = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.kvs_fa_coordinator_client_secret.id})"
     "CoordinatorOrchestratorTimeoutSecs"      = "600"
   }
+  https_only                 = true
+
   site_config {
     always_on      = true
     ip_restriction = []
+    ftps_state     = "FtpsOnly"
 
     cors {
       allowed_origins = []

--- a/terraform/functions-pdf-generator.tf
+++ b/terraform/functions-pdf-generator.tf
@@ -20,9 +20,12 @@ resource "azurerm_function_app" "fa_pdf_generator" {
     "StubBlobStorageConnectionString"         = var.stub_blob_storage_connection_string
     "AuthorizationClaim"                      = "application.create"
   }
+  https_only                 = true
+
   site_config {
     always_on      = true
     ip_restriction = []
+    ftps_state     = "FtpsOnly"
   }
 
   identity {

--- a/terraform/functions-text-extractor.tf
+++ b/terraform/functions-text-extractor.tf
@@ -27,9 +27,12 @@ resource "azurerm_function_app" "fa_text_extractor" {
     "blob__UserDelegationKeyExpirySecs"        = 3600
     "AuthorizationClaim"                      = "application.read"
   }
+  https_only                 = true
+
   site_config {
     always_on      = true
     ip_restriction = []
+    ftps_state     = "FtpsOnly"
   }
 
   identity {

--- a/terraform/storage-account.tf
+++ b/terraform/storage-account.tf
@@ -8,6 +8,8 @@ resource "azurerm_storage_account" "sa" {
   account_tier              = "Standard"
   enable_https_traffic_only = true
 
+  min_tls_version = "TLS1_2"
+
   network_rules {
     default_action = "Allow"
   }

--- a/text-extractor/text-extractor.csproj
+++ b/text-extractor/text-extractor.csproj
@@ -14,7 +14,7 @@
 
 
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.12.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Weak SSL/TLS protocols should not be used in terraform/storage-account
Update nuget packages for Azure.Storage.Blobs and Microsoft.Extensions.Azure because of detected security vulnerabilities