### PR TITLE
Allowed Redact PDF to use new auth v2 

### DIFF
--- a/Common/Handlers/AuthorizationValidator.cs
+++ b/Common/Handlers/AuthorizationValidator.cs
@@ -24,13 +24,13 @@ namespace common.Handlers
             _log = log;
         }
 
-        public async Task<Tuple<bool, string>> ValidateTokenAsync(AuthenticationHeaderValue authenticationHeader)
+        public async Task<Tuple<bool, string>> ValidateTokenAsync(AuthenticationHeaderValue authenticationHeader, string validAudience = "")
         {
             if (authenticationHeader == null) return new Tuple<bool, string>(false, string.Empty);
             if (string.IsNullOrEmpty(authenticationHeader.Parameter)) throw new ArgumentNullException(nameof(authenticationHeader));
 
             var issuer = $"https://sts.windows.net/{Environment.GetEnvironmentVariable("CallingAppTenantId")}/";
-            var audience = Environment.GetEnvironmentVariable("CallingAppValidAudience");
+            var audience = string.IsNullOrWhiteSpace(validAudience) ? Environment.GetEnvironmentVariable("CallingAppValidAudience") : validAudience;
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(issuer + "/.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever(),
                 new HttpDocumentRetriever());
 

--- a/Common/Handlers/IAuthorizationValidator.cs
+++ b/Common/Handlers/IAuthorizationValidator.cs
@@ -6,7 +6,7 @@ namespace common.Handlers
 {
     public interface IAuthorizationValidator
     {
-        Task<Tuple<bool, string>> ValidateTokenAsync(AuthenticationHeaderValue authenticationHeader);
+        Task<Tuple<bool, string>> ValidateTokenAsync(AuthenticationHeaderValue authenticationHeader, string validAudience = "");
     }
 }
 

--- a/coordinator.tests/Functions/CoordinatorStartTests.cs
+++ b/coordinator.tests/Functions/CoordinatorStartTests.cs
@@ -61,9 +61,9 @@ namespace coordinator.tests.Functions
             _mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<Exception>()))
                 .Returns(new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
-            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsNotNull<AuthenticationHeaderValue>()))
+            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsNotNull<AuthenticationHeaderValue>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(true, _accessToken));
-            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(null))
+            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(null, It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 
             _coordinatorStart = new CoordinatorStart(_mockExceptionHandler.Object, _mockLogger.Object, mockAuthorizationValidator.Object);

--- a/pdf-generator.tests/Functions/GeneratePdfTests.cs
+++ b/pdf-generator.tests/Functions/GeneratePdfTests.cs
@@ -67,7 +67,7 @@ namespace pdf_generator.tests.Functions
 			var mockPdfOrchestratorService = new Mock<IPdfOrchestratorService>();
 			_mockExceptionHandler = new Mock<IExceptionHandler>();
 
-			_mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>()))
+			_mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(true, _fixture.Create<string>()));
 			_mockJsonConvertWrapper.Setup(wrapper => wrapper.DeserializeObject<GeneratePdfRequest>(_serializedGeneratePdfRequest))
 				.Returns(_generatePdfRequest);
@@ -92,7 +92,7 @@ namespace pdf_generator.tests.Functions
 		[Fact]
 		public async Task Run_ReturnsUnauthorizedWhenUnauthorized()
 		{
-            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>()))
+            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(),It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 			_errorHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 			_mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<UnauthorizedException>()))

--- a/pdf-generator.tests/Functions/RedactPdfTests.cs
+++ b/pdf-generator.tests/Functions/RedactPdfTests.cs
@@ -47,7 +47,7 @@ namespace pdf_generator.tests.Functions
             _mockExceptionHandler = new Mock<IExceptionHandler>();
             var mockDocumentRedactionService = new Mock<IDocumentRedactionService>();
 
-            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>()))
+            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(true, _fixture.Create<string>()));
             _mockJsonConvertWrapper.Setup(wrapper => wrapper.SerializeObject(It.IsAny<RedactPdfResponse>()))
                 .Returns(_serializedRedactPdfResponse);
@@ -61,7 +61,7 @@ namespace pdf_generator.tests.Functions
         [Fact]
         public async Task Run_ReturnsUnauthorizedWhenUnauthorized()
         {
-            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>()))
+            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
             _mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<UnauthorizedException>()))
                 .Returns(new HttpResponseMessage(HttpStatusCode.Unauthorized));

--- a/pdf-generator/Functions/RedactPdf.cs
+++ b/pdf-generator/Functions/RedactPdf.cs
@@ -38,7 +38,7 @@ namespace pdf_generator.Functions
         {
             try
             {
-                var authValidation = await _authorizationValidator.ValidateTokenAsync(request.Headers.Authorization);
+                var authValidation = await _authorizationValidator.ValidateTokenAsync(request.Headers.Authorization, Environment.GetEnvironmentVariable("RedactPdfValidAudience"));
                 if (!authValidation.Item1)
                     throw new UnauthorizedException("Token validation failed");
 

--- a/text-extractor.tests/Functions/ExtractTextTests.cs
+++ b/text-extractor.tests/Functions/ExtractTextTests.cs
@@ -54,7 +54,7 @@ namespace text_extractor.tests.Functions
 			_mockExceptionHandler = new Mock<IExceptionHandler>();
 			_mockAnalyzeResults = new Mock<AnalyzeResults>();
 
-			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>()))
+			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(true, fixture.Create<string>()));
 			_mockJsonConvertWrapper.Setup(wrapper => wrapper.DeserializeObject<ExtractTextRequest>(_serializedExtractTextRequest))
 				.Returns(_extractTextRequest);
@@ -74,7 +74,7 @@ namespace text_extractor.tests.Functions
 		[Fact]
 		public async Task Run_ReturnsUnauthorizedWhenUnauthorized()
 		{
-			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>()))
+			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 			_errorHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 			_mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<UnauthorizedException>()))


### PR DESCRIPTION
Allowed Redact PDF to use new auth v2 by allowing for different audience (it is called via OBO from Gateway just like Coordinator Start, whereas the other pipeline calls are issued via client credential flow) 