### PR TITLE
Fixed invalid auth definitions and fixed duplicate key entry in co.tf

### DIFF
--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -2,10 +2,14 @@ env = "dev"
 env_suffix = "-dev"
 stub_blob_storage_connection_string="DefaultEndpointsProtocol=https;AccountName=sadevcmsdocumentservices;AccountKey=06beksVS54Cw5YqSLpvKrJStK8yYMsSui1cPO3MT4+pnHys6sCBFqBq17ix5ZGXuL5cHxnBIslXzZsL24ZRa7g==;EndpointSuffix=core.windows.net"
 fa_rumpole_gateway_identity_principal_id="0cb4da1a-7c17-4b51-9ba9-36b8819485c9"
-coordinator_user_impersonation_scope_id="42b54fc3-3b35-4109-95f5-e62d23f739d8"
 app_service_plan_sku = {
     size = "B3"
     tier = "Basic"
+}
+
+coordinator_details = {
+	application_registration_id="b8f25b3d-d89c-4d2a-a010-31e426e5eb99"
+	user_impersonation_scope_id="2e10e043-8554-4bef-9302-13479a55c68d"
 }
 
 pdf_generator_details = {

--- a/terraform/functions-text-extractor.tf
+++ b/terraform/functions-text-extractor.tf
@@ -42,17 +42,6 @@ resource "azurerm_function_app" "fa_text_extractor" {
     type = "SystemAssigned"
   }
 
-  auth_settings {
-    enabled                       = true
-    issuer                        = "https://sts.windows.net/${data.azurerm_client_config.current.tenant_id}/"
-    unauthenticated_client_action = "RedirectToLoginPage"
-    default_provider              = "AzureActiveDirectory"
-    active_directory {
-      client_id                   = azuread_application.fa_text_extractor.application_id
-      allowed_audiences           = ["api://fa-${local.resource_name}-text-extractor"]
-    }
-  }
-
   lifecycle {
     ignore_changes = [
       app_settings["WEBSITES_ENABLE_APP_SERVICE_STORAGE"],

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,13 @@ variable "gateway_details" {
   })
 }
 
+variable "coordinator_details" {
+  type = object({
+    application_registration_id = string
+    user_impersonation_scope_id = string
+  })
+}
+
 variable "pdf_generator_details" {
   type = object({
     application_registration_id = string
@@ -44,10 +51,6 @@ variable "text_extractor_details" {
     application_registration_id = string
     application_text_extraction_role_id = string
   })
-}
-
-variable "coordinator_user_impersonation_scope_id" {
-  type = string
 }
 
 # TODO get rid of this as it will change every time gateway is rebuilt


### PR DESCRIPTION
Fix duplicate entry in required resource access for coordinator. Removed auth settings until auth v2 fully supported by terraform. If not, this information will need to be manually created for prod or any other environment.