### PR TITLE
Altered web hook to process authentication header sent via AD event s…

### DIFF
--- a/Common/Constants/PipelineConstants.cs
+++ b/Common/Constants/PipelineConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace Common.Constants
+﻿using System.Diagnostics.Contracts;
+
+namespace Common.Constants
 {
     public static class AuthenticationKeys
     {
@@ -6,5 +8,23 @@
         public const string AzureAuthenticationInstanceUrl = "https://login.microsoftonline.com/";
         public const string AzureAuthenticationAssertionType = "urn:ietf:params:oauth:grant-type:jwt-bearer";
         public const string Bearer = "Bearer";
+    }
+
+    public static class EventGridEvents
+    {
+        public const string SubscriptionValidationEvent = "Microsoft.EventGrid.SubscriptionValidationEvent";
+        public const string BlobDeletedEvent = "Microsoft.Storage.BlobDeleted";
+    }
+
+    public static class PipelineRoles
+    {
+        public const string ExtractText = "application.extracttext";
+        public const string HandlePolarisDocumentDeleted = "";
+    }
+
+    public static class PipelineScopes
+    {
+        public const string ExtractText = "";
+        public const string HandlePolarisDocumentDeleted = "";
     }
 }

--- a/Common/Domain/Validation/SubscriptionValidationEventData.cs
+++ b/Common/Domain/Validation/SubscriptionValidationEventData.cs
@@ -1,0 +1,6 @@
+namespace Common.Domain.Validation;
+
+public class SubscriptionValidationEventData
+{
+    public string ValidationCode { get; set; }
+}

--- a/Common/Domain/Validation/SubscriptionValidationResponseData.cs
+++ b/Common/Domain/Validation/SubscriptionValidationResponseData.cs
@@ -1,0 +1,6 @@
+namespace Common.Domain.Validation;
+
+public class SubscriptionValidationResponseData
+{
+    public string ValidationResponse { get; set; }
+}

--- a/Common/Handlers/IAuthorizationValidator.cs
+++ b/Common/Handlers/IAuthorizationValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
@@ -6,7 +7,8 @@ namespace common.Handlers
 {
     public interface IAuthorizationValidator
     {
-        Task<Tuple<bool, string>> ValidateTokenAsync(AuthenticationHeaderValue authenticationHeader, Guid correlationId, string validAudience = "");
+        Task<Tuple<bool, string>> ValidateTokenAsync(AuthenticationHeaderValue authenticationHeader, Guid correlationId, string requiredScopes = null, 
+            string requiredRoles = null);
     }
 }
 

--- a/coordinator.tests/Functions/CoordinatorStartTests.cs
+++ b/coordinator.tests/Functions/CoordinatorStartTests.cs
@@ -57,9 +57,9 @@ namespace coordinator.tests.Functions
             _mockDurableOrchestrationClient.Setup(client => client.CreateCheckStatusResponse(_httpRequestMessage, _caseId, false))
                 .Returns(_httpResponseMessage);
 
-            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsNotNull<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsNotNull<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(true, _accessToken));
-            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(null, It.IsAny<Guid>(), It.IsAny<string>()))
+            mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(null, It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 
             _coordinatorStart = new CoordinatorStart(_mockLogger.Object, mockAuthorizationValidator.Object);

--- a/pdf-generator.tests/Functions/GeneratePdfTests.cs
+++ b/pdf-generator.tests/Functions/GeneratePdfTests.cs
@@ -72,7 +72,7 @@ namespace pdf_generator.tests.Functions
 			_mockLogger = new Mock<ILogger<GeneratePdf>>();
 			_correlationId = _fixture.Create<Guid>();
 
-			_mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+			_mockAuthorizationValidator.Setup(x => x.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(true, _fixture.Create<string>()));
 			_mockJsonConvertWrapper.Setup(wrapper => wrapper.DeserializeObject<GeneratePdfRequest>(_serializedGeneratePdfRequest))
 				.Returns(_generatePdfRequest);
@@ -98,7 +98,7 @@ namespace pdf_generator.tests.Functions
 		[Fact]
 		public async Task Run_ReturnsExceptionWhenCorrelationIdIsMissing()
 		{
-			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 			_errorHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 			_mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<Exception>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<ILogger<GeneratePdf>>()))
@@ -113,7 +113,7 @@ namespace pdf_generator.tests.Functions
 		[Fact]
 		public async Task Run_ReturnsUnauthorizedWhenUnauthorized()
 		{
-            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 			_errorHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 			_mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<UnauthorizedException>(), It.IsAny<Guid>(), It.IsAny<string>(), _mockLogger.Object))

--- a/pdf-generator.tests/Functions/RedactPdfTests.cs
+++ b/pdf-generator.tests/Functions/RedactPdfTests.cs
@@ -51,7 +51,7 @@ namespace pdf_generator.tests.Functions
             _mockExceptionHandler = new Mock<IExceptionHandler>();
             var mockDocumentRedactionService = new Mock<IDocumentRedactionService>();
 
-            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(true, _fixture.Create<string>()));
             _mockJsonConvertWrapper.Setup(wrapper => wrapper.SerializeObject(It.IsAny<RedactPdfResponse>()))
                 .Returns(_serializedRedactPdfResponse);
@@ -68,7 +68,7 @@ namespace pdf_generator.tests.Functions
         [Fact]
         public async Task Run_ReturnsUnauthorizedWhenUnauthorized()
         {
-            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+            _mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
             _mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<UnauthorizedException>(), It.IsAny<Guid>(), It.IsAny<string>(), _loggerMock.Object))
                 .Returns(new HttpResponseMessage(HttpStatusCode.Unauthorized));

--- a/text-extractor.tests/Functions/ExtractTextTests.cs
+++ b/text-extractor.tests/Functions/ExtractTextTests.cs
@@ -60,7 +60,7 @@ namespace text_extractor.tests.Functions
 
 			_correlationId = fixture.Create<Guid>();
 
-			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(true, fixture.Create<string>()));
 			_mockJsonConvertWrapper.Setup(wrapper => wrapper.DeserializeObject<ExtractTextRequest>(_serializedExtractTextRequest))
 				.Returns(_extractTextRequest);
@@ -83,7 +83,7 @@ namespace text_extractor.tests.Functions
 		[Fact]
 		public async Task Run_ReturnsExceptionWhenCorrelationIdIsMissing()
 		{
-			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 			_errorHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 			_mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<Exception>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<ILogger<ExtractText>>()))
@@ -98,7 +98,7 @@ namespace text_extractor.tests.Functions
 		[Fact]
 		public async Task Run_ReturnsUnauthorizedWhenUnauthorized()
 		{
-			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>()))
+			_mockAuthorizationValidator.Setup(handler => handler.ValidateTokenAsync(It.IsAny<AuthenticationHeaderValue>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
 				.ReturnsAsync(new Tuple<bool, string>(false, string.Empty));
 			_errorHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 			_mockExceptionHandler.Setup(handler => handler.HandleException(It.IsAny<UnauthorizedException>(), It.IsAny<Guid>(), It.IsAny<string>(), _mockLogger.Object))

--- a/text-extractor/Functions/ExtractText.cs
+++ b/text-extractor/Functions/ExtractText.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Common.Constants;
 using common.Domain.Exceptions;
 using common.Handlers;
 using Common.Logging;
@@ -61,7 +62,7 @@ namespace text_extractor.Functions
                 _log.LogMethodEntry(currentCorrelationId, loggingName, string.Empty);
 
                 var authValidation =
-                    await _authorizationValidator.ValidateTokenAsync(request.Headers.Authorization, currentCorrelationId);
+                    await _authorizationValidator.ValidateTokenAsync(request.Headers.Authorization, currentCorrelationId, PipelineScopes.ExtractText, PipelineRoles.ExtractText);
                 if (!authValidation.Item1)
                     throw new UnauthorizedException("Token validation failed");
 

--- a/text-extractor/Functions/HandlePolarisDocumentDeleted.cs
+++ b/text-extractor/Functions/HandlePolarisDocumentDeleted.cs
@@ -2,40 +2,45 @@
 // http://localhost:7071/runtime/webhooks/EventGrid?functionName=HandlePolarisDocumentDeleted
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;
+using Common.Constants;
+using common.Domain.Exceptions;
+using common.Handlers;
 using Common.Logging;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.EventGrid;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using text_extractor.Services.SearchIndexService;
 
 namespace text_extractor.Functions;
 
 public class HandlePolarisDocumentDeleted
 {
-    private const string BlobDeletedEvent = "Microsoft.Storage.BlobDeleted";
     private readonly ILogger<HandlePolarisDocumentDeleted> _logger;
     private readonly ISearchIndexService _searchIndexService;
+    private readonly IAuthorizationValidator _authorizationValidator;
     
-    public HandlePolarisDocumentDeleted(ILogger<HandlePolarisDocumentDeleted> logger, ISearchIndexService searchIndexService)
+    public HandlePolarisDocumentDeleted(IAuthorizationValidator authorizationValidator, ILogger<HandlePolarisDocumentDeleted> logger, ISearchIndexService searchIndexService)
     {
         _logger = logger;
         _searchIndexService = searchIndexService;
+        _authorizationValidator = authorizationValidator;
     }
 
     /// <summary>
     /// Handles blob-deletion events raised by Azure Storage, when case documents grow stale either by lack of interaction with the CMS case or the CMS case is archived/closed
     /// The initial deletion is carried out via a LifeCycle Management policy setup against the storage table containing the documents 
     /// </summary>
-    /// <param name="eventGridEvent"></param>
-    /// <param name="context"></param>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="NullReferenceException"></exception>
     [FunctionName("HandlePolarisDocumentDeleted")]
-    public async Task RunAsync([EventGridTrigger] EventGridEvent eventGridEvent, ExecutionContext context)
+    public async Task<HttpResponseMessage> RunAsync([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequestMessage request)
     {
         var processCompleted = false;
         const string loggerSource = "HandlePolarisDocumentDeleted - EventGrid - Event";
@@ -43,6 +48,15 @@ public class HandlePolarisDocumentDeleted
 
         try
         {
+            var authValidation = await _authorizationValidator.ValidateTokenAsync(request.Headers.Authorization, correlationId, PipelineScopes.HandlePolarisDocumentDeleted, PipelineRoles.HandlePolarisDocumentDeleted);
+            if (!authValidation.Item1)
+                throw new UnauthorizedException("Token validation failed");
+            
+            if (request.Content == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var requestMessageContent = await request.Content.ReadAsStringAsync();
+            var eventGridEvent = (JsonConvert.DeserializeObject<EventGridEvent[]>(requestMessageContent) ?? Array.Empty<EventGridEvent>()).FirstOrDefault();
             if (eventGridEvent == null || string.IsNullOrWhiteSpace(eventGridEvent.EventType))
             {
                 throw new ArgumentNullException(nameof(eventGridEvent), "Null or invalid Event Grid Event received");
@@ -50,12 +64,26 @@ public class HandlePolarisDocumentDeleted
 
             _logger.LogMethodEntry(correlationId, loggerSource, ReturnEventGridTopLevel(eventGridEvent));
 
-            if (eventGridEvent.EventType == BlobDeletedEvent)
+            // Validate whether EventType is of "Microsoft.EventGrid.SubscriptionValidationEvent"
+            if (string.Equals(eventGridEvent.EventType, EventGridEvents.SubscriptionValidationEvent, StringComparison.OrdinalIgnoreCase))
+            {
+                var eventData = eventGridEvent.Data.ToObjectFromJson<SubscriptionValidationEventData>();
+                var responseData = new Common.Domain.Validation.SubscriptionValidationResponseData
+                {
+                    ValidationResponse = eventData.ValidationCode
+                };
+
+                return responseData.ValidationResponse != null 
+                    ? request.CreateResponse(HttpStatusCode.OK, responseData) 
+                    : request.CreateErrorResponse(HttpStatusCode.BadRequest, "Could not deal with the Event Grid subscription validation request");
+            }
+            
+            if (eventGridEvent.EventType == EventGridEvents.BlobDeletedEvent)
             {
                 var eventData = eventGridEvent.Data.ToObjectFromJson<StorageBlobDeletedEventData>();
                 if (eventData == null)
                     throw new NullReferenceException("Could not deserialize event data into the expected type: 'StorageBlobDeletedEventData'");
-                
+        
                 _logger.LogMethodFlow(correlationId, loggerSource, ReturnEventGridEventLevel(eventData));
 
                 var blobDetails = new Uri(eventData.Url).PathAndQuery.Split("/");
@@ -63,25 +91,28 @@ public class HandlePolarisDocumentDeleted
                 var documentId = blobDetails[4].Replace(".pdf", "", StringComparison.OrdinalIgnoreCase);
 
                 await _searchIndexService.RemoveResultsForDocumentAsync(caseId, documentId, correlationId);
+                
+                _logger.LogMethodFlow(correlationId, loggerSource, $"Removed caseId: {caseId}, documentId: '{documentId}' from the search index");
             }
             else
             {
-                var wrongMessageTypeReceived =
-                    $"Event grid event type was not of type Microsoft.Storage.BlobDeleted, but rather {eventGridEvent.EventType} - ignoring the raised event";
+                var wrongMessageTypeReceived = $"Event grid event type was not of type Microsoft.Storage.BlobDeleted, but rather {eventGridEvent.EventType} - ignoring the raised event";
                 _logger.LogMethodFlow(correlationId, loggerSource, wrongMessageTypeReceived);
             }
-
+            
             processCompleted = true;
         }
         catch (Exception ex)
         {
             _logger.LogMethodError(correlationId, loggerSource, ex.Message, ex);
-            throw;
+            return request.CreateErrorResponse(HttpStatusCode.BadRequest, ex.Message);
         }
         finally
         {
             _logger.LogMethodExit(correlationId, loggerSource, $"Blob deletion event completed successfully: '{processCompleted}'");
         }
+        
+        return request.CreateResponse(HttpStatusCode.OK);
     }
 
     private static string ReturnEventGridTopLevel(EventGridEvent eventGridEvent)
@@ -96,7 +127,7 @@ public class HandlePolarisDocumentDeleted
 
     private static string ReturnEventGridEventLevel(StorageBlobDeletedEventData eventData)
     {
-        return $@"Received {BlobDeletedEvent} Event: 
+        return $@"Received {EventGridEvents.BlobDeletedEvent} Event: 
             - Api=[{eventData.Api}]
             - BlobType=[{eventData.BlobType}]
             - ClientRequestId=[{eventData.ClientRequestId}]


### PR DESCRIPTION
…ubscription. Altered auth to allow the function app to specify the valid scopes and/or roles that apply to the auth check. Extract text has a valid role, but the web hook has neither a scope nor a role - it has already authenticated itself to AD and has now concluded a subscription validation handshake.